### PR TITLE
ci: use path "/en-au/solutions" for PSI tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,5 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 Fix #<gh-issue-id>
 
 Test URLs:
-- Before: https://main--bitdefender--hlxsites.hlx.page/
-- After: https://<branch>--bitdefender--hlxsites.hlx.page/
+- Before: https://main--bitdefender--hlxsites.hlx.page/en-au/solutions/
+- After: https://<branch>--bitdefender--hlxsites.hlx.page/en-au/solutions/


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--bitdefender--hlxsites.hlx.page/en-au/solutions/
- After: https://pr-checks-against-solutions--bitdefender--hlxsites.hlx.page/en-au/solutions/
