### PR TITLE
Changed green tag syntax

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -229,20 +229,12 @@ export async function decorateTags(element) {
   const tagTypes = [
     { regex: /\[#(.*?)#\]/g, className: 'dark-blue' },
     { regex: /\[{(.*?)}\]/g, className: 'light-blue' },
-    { regex: /\[(.*?)\]/g, className: 'green' },
+    { regex: /\[\$(.*?)\$\]/g, className: 'green' },
   ];
 
   function replaceTags(inputValue) {
     let nodeValue = inputValue; // Create a local copy to work on
     let replaced = false;
-
-    const exceptionPattern = /\$\[(.*?)]\$/g;
-
-    if (exceptionPattern.test(nodeValue)) {
-      // Removing the $ signs around the tag
-      nodeValue = nodeValue.replace(exceptionPattern, (match, p1) => `[${p1}]`);
-      return { nodeValue, replaced };
-    }
 
     tagTypes.forEach((tagType) => {
       let match = tagType.regex.exec(nodeValue);

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -236,6 +236,14 @@ export async function decorateTags(element) {
     let nodeValue = inputValue; // Create a local copy to work on
     let replaced = false;
 
+    const exceptionPattern = /\$\[(.*?)]\$/g;
+
+    if (exceptionPattern.test(nodeValue)) {
+      // Removing the $ signs around the tag
+      nodeValue = nodeValue.replace(exceptionPattern, (match, p1) => `[${p1}]`);
+      return { nodeValue, replaced };
+    }
+
     tagTypes.forEach((tagType) => {
       let match = tagType.regex.exec(nodeValue);
       while (match !== null) {
@@ -251,8 +259,9 @@ export async function decorateTags(element) {
 
   function replaceTagsInNode(node) {
     if (node.nodeType === Node.TEXT_NODE) {
-      const { nodeValue, replaced } = replaceTags(node.nodeValue);
-      if (replaced) {
+      const originalValue = node.nodeValue;
+      const { nodeValue } = replaceTags(originalValue);
+      if (nodeValue !== originalValue) { // This checks if the nodeValue has been modified.
         const newNode = document.createElement('span');
         newNode.innerHTML = nodeValue;
         node.parentNode.replaceChild(newNode, node);


### PR DESCRIPTION
Green tags now get created by using [$...$]

Fix #139 

Test URLs:
- Before: https://main--bitdefender--hlxsites.hlx.page/solutions/antivirus
- After: https://tag-exceptions--bitdefender--hlxsites.hlx.page/solutions/antivirus