### PR TITLE
Sticky navigation mobile overlapping menu

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -16,6 +16,7 @@ header p {
   position: sticky;
   top: 0;
   transition: all 0.3s ease-in-out;
+  background-color: var(--white-color);
 }
 
 nav {

--- a/blocks/sticky-navigation/sticky-navigation.css
+++ b/blocks/sticky-navigation/sticky-navigation.css
@@ -3,28 +3,23 @@
 }
 
 main .section.sticky-navigation-container {
-  position: static;
   padding-top: 0;
-  overflow: visible;
 }
 
 .sticky-navigation {
   cursor: pointer;
   background-color: var(--white-color);
-  position: sticky;
-  top: 0;
-  width: 100%;
-  max-width: 20in;
+  position: relative;
   z-index: 101;
 }
 
-/* .sticky-navigation.fixed-nav {
-  position: sticky;
-  top: 0;
+.sticky-navigation.fixed-nav {
+  position: fixed;
   width: 100%;
   max-width: 20in;
   z-index: 101;
-} */
+  top: -1px;
+}
 
 .sticky-navigation .menu-with-button {
   display: none;

--- a/blocks/sticky-navigation/sticky-navigation.css
+++ b/blocks/sticky-navigation/sticky-navigation.css
@@ -3,14 +3,28 @@
 }
 
 main .section.sticky-navigation-container {
+  position: static;
   padding-top: 0;
+  overflow: visible;
 }
 
 .sticky-navigation {
   cursor: pointer;
-  position: relative;
   background-color: var(--white-color);
+  position: sticky;
+  top: 0;
+  width: 100%;
+  max-width: 20in;
+  z-index: 101;
 }
+
+/* .sticky-navigation.fixed-nav {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  max-width: 20in;
+  z-index: 101;
+} */
 
 .sticky-navigation .menu-with-button {
   display: none;
@@ -98,13 +112,7 @@ main .section.sticky-navigation-container {
   display: flex;
 }
 
-.sticky-navigation.fixed-nav {
-  position: fixed;
-  top: 0;
-  width: 100%;
-  max-width: 20in;
-  z-index: 99999;
-}
+
 
 .sticky-navigation .button-container {
   margin:0;

--- a/blocks/sticky-navigation/sticky-navigation.css
+++ b/blocks/sticky-navigation/sticky-navigation.css
@@ -18,7 +18,7 @@ main .section.sticky-navigation-container {
   width: 100%;
   max-width: 20in;
   z-index: 101;
-  top: -1px;
+  top: 0;
 }
 
 .sticky-navigation .menu-with-button {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #105

Test URLs:
- Before: https://main--bitdefender--hlxsites.hlx.page/solutions/
- After: https://105-mobile-menu--bitdefender--hlxsites.hlx.page/solutions/