### PR TITLE
Fix quote carousel styling issues identified during screenshot testing

### DIFF
--- a/blocks/quote-carousel/quote-carousel.css
+++ b/blocks/quote-carousel/quote-carousel.css
@@ -1,3 +1,7 @@
+main .quote-carousel-wrapper {
+  max-width: 100%;
+}
+
 main .quote-carousel .slides-container {
   border-radius: 8px;
   max-width: 630px;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -786,7 +786,7 @@ main .section.cta, .section.columnar {
 }
 
 @media (min-width: 768px) {
-  .columnar-container {
+  .image-overflow .columnar-container {
     flex-direction: row;
   }
 }
@@ -794,6 +794,7 @@ main .section.cta, .section.columnar {
 @media (min-width: 992px) {
   .columnar-container {
     padding: 0 50px;
+    flex-direction: row;
   }
 }
 
@@ -806,6 +807,10 @@ main .section.cta, .section.columnar {
 .columnar-container .left-col {
   flex: 1 1 50%;
   justify-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-around;
 }
 
 .columnar-container .right-col {
@@ -815,15 +820,6 @@ main .section.cta, .section.columnar {
   overflow: visible;
   flex-direction: column;
   justify-content: flex-end;
-}
-
-@media (min-width: 768px) {
-  .columnar-container .left-col {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: space-around;
-  }
 }
 
 @media (min-width: 992px) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -785,6 +785,12 @@ main .section.cta, .section.columnar {
   margin: 0 auto;
 }
 
+@media (min-width: 768px) {
+  .columnar-container {
+    flex-flow: row;
+  }
+}
+
 @media (min-width: 992px) {
   .columnar-container {
     padding: 0 50px;
@@ -798,12 +804,8 @@ main .section.cta, .section.columnar {
 }
 
 .columnar-container .left-col {
-  display: flex;
-  flex-direction: column;
   flex: 1 1 50%;
   justify-items: center;
-  align-items: center;
-  justify-content: space-around;
 }
 
 .columnar-container .right-col {
@@ -813,6 +815,15 @@ main .section.cta, .section.columnar {
   overflow: visible;
   flex-direction: column;
   justify-content: flex-end;
+}
+
+@media (min-width: 768px) {
+  .columnar-container .left-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-around;
+  }
 }
 
 @media (min-width: 992px) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -780,14 +780,14 @@ main .section.cta, .section.columnar {
 .columnar-container {
   padding: 0 20px;
   display: flex;
-  flex-flow: column;
+  flex-direction: column;
   max-width: 1300px;
   margin: 0 auto;
 }
 
 @media (min-width: 768px) {
   .columnar-container {
-    flex-flow: row;
+    flex-direction: row;
   }
 }
 
@@ -859,7 +859,7 @@ main .section.cta, .section.columnar {
 
 @media(min-width: 992px) {
   .columnar-container {
-    flex-flow: row;
+    flex-direction: row;
   }
 }
 


### PR DESCRIPTION
Fixed quote carousel on mobile:
from: 
![image](https://github.com/hlxsites/bitdefender/assets/1336823/5cce9757-e740-43d9-bbdf-e5a3c180c16a)
to
![image](https://github.com/hlxsites/bitdefender/assets/1336823/5dd55569-dfe4-4c53-9384-16c71efa8a38)


Test URLs:
- Before: https://main--bitdefender--hlxsites.hlx.page/solutions/mobile-security-android
- After: https://fix-image-section--bitdefender--hlxsites.hlx.page/solutions/mobile-security-android