### PR TITLE
Accordion style fixes

### DIFF
--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -63,7 +63,6 @@
   border-color: #006eff;
   border-style: solid;
   border-width: 0 2px 2px 0;
-  top: 40px;
   content: "";
   width: 10px;
   height: 10px;

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -8,7 +8,7 @@
 
 .accordion .accordion-item {
   margin: 16px 0;
-  padding: 18px 20px;
+  padding: 18px 54px;
   border-radius: 10px;
   border-color: rgb(229 231 235);
   border-width: 0;
@@ -44,7 +44,7 @@
   transition: top .3s ease-in-out,transform .3s ease-in-out,-webkit-transform .3s ease-in-out;
 }
 
-.accordion-item .accordion-item-header > :nth-child(1) {
+.accordion-item .accordion-item-header > h3 {
   display: inline-block;
 }
 
@@ -105,37 +105,7 @@
   display: block;
 }
 
-.accordion .accordion-item-header > :nth-child(1) {
-  margin-bottom: 0;
-  font-size: var(--heading-font-size-xs);
-  flex: 1;
-}
-
-.accordion.faq .accordion-item-header > :nth-child(1) {
-  margin-bottom: 15px;
-}
-
-.accordion.terms-of-use .accordion-item-header > :nth-child(1) {
-  font-size: var(--heading-font-size-xxs);
-  margin-bottom: 0;
-}
-
-@media (min-width: 767px) { /* tablet */
-  .accordion .accordion-item {
-    padding: 18px 54px;
-  }
-
-  .accordion .accordion-item-header > :nth-child(1) {
-    font-size: var(--heading-font-size-s);
-  }
-
-  .accordion.terms-of-use .accordion-item-header > :nth-child(1) {
-    font-size: var(--heading-font-size-xs);
-  }
-}
-
 @media (min-width: 992px) { /* desktop */
-
   .accordion .accordion-item-header h3 {
     font-size: var(--heading-font-size-s);
   }
@@ -149,20 +119,12 @@
     padding: 0 var(--section-desktop-padding);
     margin: 0 auto;
   }
-
-  .accordion .accordion-item-header > :nth-child(1) {
-    font-size: var(--heading-font-size-m);
-  }
 }
 
 @media (min-width: 1600px) { /* large desktop */
   .accordion-wrapper {
     max-width: var(--section-large-desktop-max-width);
     padding: 0 var(--section-large-desktop-padding);
-  }
-
-  .accordion .accordion-item-header > :nth-child(1) {
-    font-size: var(--heading-font-size-l);
   }
 }
 

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -8,7 +8,7 @@
 
 .accordion .accordion-item {
   margin: 16px 0;
-  padding: 18px 54px;
+  padding: 18px 20px;
   border-radius: 10px;
   border-color: rgb(229 231 235);
   border-width: 0;
@@ -22,6 +22,8 @@
   font-size: 18px;
   line-height: 27px;
   color: #000;
+  display: flex;
+  align-items: center;
 }
 
 .accordion-item-header::after {
@@ -38,7 +40,7 @@
   transition: top .3s ease-in-out,transform .3s ease-in-out,-webkit-transform .3s ease-in-out;
 }
 
-.accordion-item .accordion-item-header h4 {
+.accordion-item .accordion-item-header > :nth-child(1) {
   display: inline-block;
 }
 
@@ -90,12 +92,45 @@
   display: block;
 }
 
+.accordion .accordion-item-header > :nth-child(1) {
+  margin-bottom: 0;
+  font-size: var(--heading-font-size-xs);
+  flex: 1;
+}
+
+.accordion.faq .accordion-item-header > :nth-child(1) {
+  margin-bottom: 15px;
+}
+
+.accordion.terms-of-use .accordion-item-header > :nth-child(1) {
+  font-size: var(--heading-font-size-xxs);
+  margin-bottom: 0;
+}
+
+@media (min-width: 767px) { /* tablet */
+  .accordion .accordion-item {
+    padding: 18px 54px;
+  }
+
+  .accordion .accordion-item-header > :nth-child(1) {
+    font-size: var(--heading-font-size-s);
+  }
+
+  .accordion.terms-of-use .accordion-item-header > :nth-child(1) {
+    font-size: var(--heading-font-size-xs);
+  }
+}
+
 @media (min-width: 992px) { /* desktop */
 
   .accordion-wrapper {
     max-width: var(--section-desktop-max-width);
     padding: 0 var(--section-desktop-padding);
     margin: 0 auto;
+  }
+
+  .accordion .accordion-item-header > :nth-child(1) {
+    font-size: var(--heading-font-size-m);
   }
 }
 
@@ -105,6 +140,9 @@
     padding: 0 var(--section-large-desktop-padding);
   }
 
+  .accordion .accordion-item-header > :nth-child(1) {
+    font-size: var(--heading-font-size-l);
+  }
 }
 
 .accordion.faq .accordion-item,

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -666,9 +666,9 @@ export function decorateButtons(element) {
           return;
         }
         // Example: <p><em><a href="example.com#something"</a></em></p>
-        if (up.childNodes.length === 1 && up.tagName === 'EM' && 
-        twoup.childNodes.length === 1 && twoup.tagName === 'P' &&
-        a.href.match(/#([A-Za-z])\w+/)) {
+        if (up.childNodes.length === 1 && up.tagName === 'EM'
+        && twoup.childNodes.length === 1 && twoup.tagName === 'P'
+        && a.href.match(/#([A-Za-z])\w+/)) {
           up.replaceWith(a);
           a.className = 'button with-arrow';
           up.classList.add('button-container');

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -670,7 +670,7 @@ export function decorateButtons(element) {
         twoup.childNodes.length === 1 && twoup.tagName === 'P' &&
         a.href.match(/#([A-Za-z])\w+/)) {
           up.replaceWith(a);
-          //a.className = 'button';
+          a.className = 'button with-arrow';
           up.classList.add('button-container');
           return;
         }

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -642,7 +642,7 @@ export function decorateButtons(element) {
           a.innerHTML = wrapButtonText(a);
           return;
         }
-        // Example: <p><a href="example.com">Text</a> (example.com)</p>
+        // Example: <p><a href="example.com/fragments/some-resource">Text</a> (example.com)</p>
         if (up.childNodes.length === 1 && up.tagName === 'P' && a.href.includes('/fragments/')) {
           a.className = 'button modal';
           up.classList.add('button-container');
@@ -663,6 +663,15 @@ export function decorateButtons(element) {
           up.classList.add('info-button-container');
           a.textContent = a.textContent.slice(1).trim();
           a.title = a.title.slice(1).trim();
+          return;
+        }
+        // Example: <p><em><a href="example.com#something"</a></em></p>
+        if (up.childNodes.length === 1 && up.tagName === 'EM' && 
+        twoup.childNodes.length === 1 && twoup.tagName === 'P' &&
+        a.href.match(/#([A-Za-z])\w+/)) {
+          up.replaceWith(a);
+          //a.className = 'button';
+          up.classList.add('button-container');
           return;
         }
         // Example: <p><a href="example.com">Text</a></p>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -644,7 +644,7 @@ a.button:hover.secondary {
   color: var(--white-color)
 }
 
-a.button.modal {
+a.button.modal, a.button.with-arrow {
   color: var(--link-color);
   font-weight: var(--font-weight-bold);
   background-color: transparent;
@@ -656,7 +656,7 @@ a.button.modal {
   text-overflow: ellipsis;
 }
 
-a.button.modal::after {
+a.button.modal::after, a.button.with-arrow::after {
   background-color: var(--link-color);
   opacity: 1;
   margin: 0;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Did some changes also on the styling of a simple link, can check on the page 
Now having the possibility to add a simple link by styling it with italic and having a parameter on it
matching something like https://example.com/solutions/small-office-security#features

On bitdefender page (https://www.bitdefender.com.au/solutions/small-office-security.html)
![image](https://github.com/hlxsites/bitdefender/assets/26941572/94790211-0c9a-4f5e-ae2d-79222e20b716)

On main
![image](https://github.com/hlxsites/bitdefender/assets/26941572/56583727-a436-4084-a5c2-e832818aa68a)

Fix #272 

Test URLs:
- Before: https://main--bitdefender--hlxsites.hlx.page/solutions/small-office-security
- After: https://accordion-style-fixes--bitdefender--hlxsites.hlx.page/solutions/small-office-security