### PR TITLE
retrict updates of links to the one with empty link

### DIFF
--- a/blocks/products/products.js
+++ b/blocks/products/products.js
@@ -373,10 +373,10 @@ export default function decorate(block) {
 
       renderNanoBlocks(col, mv);
 
-      // listen to ProductCard change and update the first button accordingly
+      // listen to ProductCard change and update the buttons pointing to the store url
       mv.subscribe((card) => {
         col.querySelectorAll('.button-container a').forEach((link) => {
-          if (link && link.href === 'http://') {
+          if (link && link.href === 'https://www.bitdefender.com/site/Store/buy/') {
             link.href = card.url;
           }
         });

--- a/blocks/products/products.js
+++ b/blocks/products/products.js
@@ -375,10 +375,11 @@ export default function decorate(block) {
 
       // listen to ProductCard change and update the first button accordingly
       mv.subscribe((card) => {
-        const link = col.querySelector('.button-container a');
-        if (link) {
-          link.href = card.url;
-        }
+        col.querySelectorAll('.button-container a').forEach((link) => {
+          if (link && link.href === 'http://') {
+            link.href = card.url;
+          }
+        });
       });
     });
     row.remove();


### PR DESCRIPTION
Update button links only if their value is 'http://'

It allows to mix buttons with static links defined by the user in the word document and links (with http://) that will be automatically updated based on the chosen plan 

Fix #365

Test URLs:
- Before: https://main--bitdefender--hlxsites.hlx.page/solutions/
- After: https://fix-button-url--bitdefender--hlxsites.hlx.page/solutions/