### PR TITLE
DEX-15580 - decorate canonical link

### DIFF
--- a/solutions/scripts/lib-franklin.js
+++ b/solutions/scripts/lib-franklin.js
@@ -917,6 +917,19 @@ export function setup() {
 }
 
 /**
+* canonical links shouldn't contain ".html" ( covered by redirects.xlsx )
+ * canonical links shouldn't end with "/"
+* */
+export function decorateCanonical(doc) {
+  const linkRelCanonical = doc.head.querySelector('[rel="canonical"]');
+  linkRelCanonical.href = linkRelCanonical.href.replace('https://', 'https://www.');
+  const lastChar = linkRelCanonical.href.slice(-1);
+  if (lastChar === '/') {
+    linkRelCanonical.href = linkRelCanonical.href.slice(0, -1);
+  }
+}
+
+/**
  * Auto initializiation.
  */
 function init() {

--- a/solutions/scripts/scripts.js
+++ b/solutions/scripts/scripts.js
@@ -12,6 +12,7 @@ import {
   loadBlocks,
   loadCSS,
   getMetadata,
+  decorateCanonical,
 } from './lib-franklin.js';
 
 import {
@@ -526,6 +527,7 @@ function loadDelayed() {
 async function loadPage() {
   pushPageLoadToDataLayer();
   await window.hlx.plugins.load('eager');
+  decorateCanonical(document);
   await loadEager(document);
   await window.hlx.plugins.load('lazy');
   await loadLazy(document);


### PR DESCRIPTION
Fix #DEX-15580

Test URLs:
- Before: https://main--bitdefender--hlxsites.hlx.page/solutions/
- After: https://DEX-15580--bitdefender--hlxsites.hlx.page/solutions/