### PR TITLE
feat: Add hreflang

### DIFF
--- a/solutions/scripts/scripts.js
+++ b/solutions/scripts/scripts.js
@@ -313,7 +313,7 @@ function addHreflangTags() {
 
   Object.keys(HREFLANG_MAP).forEach((key) => {
     const hreflang = HREFLANG_MAP[key][0];
-    const href = `${HREFLANG_MAP[key][1].baseUrl}${path}${pathCount > 1 ? HREFLANG_MAP[key][1].pageType: ''}`;
+    const href = `${HREFLANG_MAP[key][1].baseUrl}${path}${pathCount > 1 ? HREFLANG_MAP[key][1].pageType : ''}`;
     const ln = document.createElement('link');
     ln.setAttribute('rel', 'alternate');
     ln.setAttribute('hreflang', hreflang);

--- a/solutions/scripts/scripts.js
+++ b/solutions/scripts/scripts.js
@@ -29,6 +29,27 @@ export const DEFAULT_COUNTRY = 'au';
 
 export const METADATA_ANAYTICS_TAGS = 'analytics-tags';
 
+const HREFLANG_MAP = [
+  ['en-ro', { baseUrl: 'https://www.bitdefender.ro', pageType: '.html' }],
+  ['de', { baseUrl: 'https://www.bitdefender.de', pageType: '.html' }],
+  ['sv', { baseUrl: 'https://www.bitdefender.se', pageType: '.html' }],
+  ['pt', { baseUrl: 'https://www.bitdefender.pt', pageType: '.html' }],
+  ['en-sv', { baseUrl: 'https://www.bitdefender.se', pageType: '.html' }],
+  ['pt-BR', { baseUrl: 'https://www.bitdefender.com.br', pageType: '.html' }],
+  ['en', { baseUrl: 'https://www.bitdefender.com', pageType: '.html' }],
+  ['it', { baseUrl: 'https://www.bitdefender.it', pageType: '.html' }],
+  ['fr', { baseUrl: 'https://www.bitdefender.fr', pageType: '.html' }],
+  ['nl-BE', { baseUrl: 'https://www.bitdefender.br', pageType: '.html' }],
+  ['es', { baseUrl: 'https://www.bitdefender.es', pageType: '.html' }],
+  ['en-AU', { baseUrl: 'https://www.bitdefender.com.au', pageType: '' }],
+  ['ro', { baseUrl: 'https://www.bitdefender.ro', pageType: '.html' }],
+  ['nl', { baseUrl: 'https://www.bitdefender.nl', pageType: '.html' }],
+  ['en-GB', { baseUrl: 'https://www.bitdefender.co.uk', pageType: '.html' }],
+  ['zh-hk', { baseUrl: 'https://www.bitdefender.com/zh-hk', pageType: '' }],
+  ['zh-tw', { baseUrl: 'https://www.bitdefender.com/zh-tw', pageType: '' }],
+  ['x-default', { baseUrl: 'https://www.bitdefender.com', pageType: '.html' }],
+];
+
 window.hlx.plugins.add('rum-conversion', {
   load: 'lazy',
   url: '../plugins/rum-conversion/src/index.js',
@@ -284,6 +305,23 @@ export default function decorateLinkedPictures(main) {
   });
 }
 
+function addHreflangTags() {
+  if (document.querySelectorAll('head link[hreflang]').length > 0) return;
+
+  const path = window.location.pathname;
+  const pathCount = path.split('/').filter(String).length;
+
+  Object.keys(HREFLANG_MAP).forEach((key) => {
+    const hreflang = HREFLANG_MAP[key][0];
+    const href = `${HREFLANG_MAP[key][1].baseUrl}${path}${pathCount > 1 ? HREFLANG_MAP[key][1].pageType: ''}`;
+    const ln = document.createElement('link');
+    ln.setAttribute('rel', 'alternate');
+    ln.setAttribute('hreflang', hreflang);
+    ln.setAttribute('href', href);
+    document.querySelector('head').appendChild(ln);
+  });
+}
+
 /**
  * Decorates the main element.
  * @param {Element} main The main element
@@ -297,6 +335,7 @@ export function decorateMain(main) {
   decorateLinkedPictures(main);
   decorateSections(main);
   decorateBlocks(main);
+  addHreflangTags();
 }
 
 /**

--- a/solutions/sitemap.xml
+++ b/solutions/sitemap.xml
@@ -23,24 +23,24 @@
     </url>
     <url>
         <loc>https://www.bitdefender.com.au/solutions/</loc>
-        <xhtml:link rel="alternate" hreflang="en-ro" href="https://www.bitdefender.ro/solutions/.html"/>
-        <xhtml:link rel="alternate" hreflang="de" href="https://www.bitdefender.de/solutions/.html"/>
-        <xhtml:link rel="alternate" hreflang="sv" href="https://www.bitdefender.se/solutions/.html"/>
-        <xhtml:link rel="alternate" hreflang="pt" href="https://www.bitdefender.pt/solutions/.html"/>
-        <xhtml:link rel="alternate" hreflang="en-sv" href="https://www.bitdefender.se/solutions/.html"/>
-        <xhtml:link rel="alternate" hreflang="pt-BR" href="https://www.bitdefender.com.br/solutions/.html"/>
-        <xhtml:link rel="alternate" hreflang="en" href="https://www.bitdefender.com/solutions/.html"/>
-        <xhtml:link rel="alternate" hreflang="it" href="https://www.bitdefender.it/solutions/.html"/>
-        <xhtml:link rel="alternate" hreflang="fr" href="https://www.bitdefender.fr/solutions/.html"/>
-        <xhtml:link rel="alternate" hreflang="nl-BE" href="https://www.bitdefender.br/solutions/.html"/>
-        <xhtml:link rel="alternate" hreflang="es" href="https://www.bitdefender.es/solutions/.html"/>
+        <xhtml:link rel="alternate" hreflang="en-ro" href="https://www.bitdefender.ro/solutions/"/>
+        <xhtml:link rel="alternate" hreflang="de" href="https://www.bitdefender.de/solutions/"/>
+        <xhtml:link rel="alternate" hreflang="sv" href="https://www.bitdefender.se/solutions/"/>
+        <xhtml:link rel="alternate" hreflang="pt" href="https://www.bitdefender.pt/solutions/"/>
+        <xhtml:link rel="alternate" hreflang="en-sv" href="https://www.bitdefender.se/solutions/"/>
+        <xhtml:link rel="alternate" hreflang="pt-BR" href="https://www.bitdefender.com.br/solutions/"/>
+        <xhtml:link rel="alternate" hreflang="en" href="https://www.bitdefender.com/solutions/"/>
+        <xhtml:link rel="alternate" hreflang="it" href="https://www.bitdefender.it/solutions/"/>
+        <xhtml:link rel="alternate" hreflang="fr" href="https://www.bitdefender.fr/solutions/"/>
+        <xhtml:link rel="alternate" hreflang="nl-BE" href="https://www.bitdefender.br/solutions/"/>
+        <xhtml:link rel="alternate" hreflang="es" href="https://www.bitdefender.es/solutions/"/>
         <xhtml:link rel="alternate" hreflang="en-AU" href="https://www.bitdefender.com.au/solutions/"/>
-        <xhtml:link rel="alternate" hreflang="ro" href="https://www.bitdefender.ro/solutions/.html"/>
-        <xhtml:link rel="alternate" hreflang="nl" href="https://www.bitdefender.nl/solutions/.html"/>
-        <xhtml:link rel="alternate" hreflang="en-GB" href="https://www.bitdefender.co.uk/solutions/.html"/>
+        <xhtml:link rel="alternate" hreflang="ro" href="https://www.bitdefender.ro/solutions/"/>
+        <xhtml:link rel="alternate" hreflang="nl" href="https://www.bitdefender.nl/solutions/"/>
+        <xhtml:link rel="alternate" hreflang="en-GB" href="https://www.bitdefender.co.uk/solutions/"/>
         <xhtml:link rel="alternate" hreflang="zh-hk" href="https://www.bitdefender.com/zh-hk/solutions/"/>
         <xhtml:link rel="alternate" hreflang="zh-tw" href="https://www.bitdefender.com/zh-tw/solutions/"/>
-        <xhtml:link rel="alternate" hreflang="x-default" href="https://www.bitdefender.com/solutions/.html"/>
+        <xhtml:link rel="alternate" hreflang="x-default" href="https://www.bitdefender.com/solutions/"/>
     </url>
     <url>
         <loc>https://www.bitdefender.com.au/solutions/mobile-security-android</loc>

--- a/tools/sitemap/create.js
+++ b/tools/sitemap/create.js
@@ -41,7 +41,8 @@ try {
         loc: `${LOCALE_URL}${row.path}`,
         'xhtml:link': Object.keys(hreflangMap).map((key) => {
           const hreflang = hreflangMap[key][0];
-          const href = `${hreflangMap[key][1].baseUrl}${row.path}${hreflangMap[key][1].pageType}`;
+          const pathCount = row.path.split('/').filter(String).length;
+          const href = `${hreflangMap[key][1].baseUrl}${row.path}${pathCount > 1 ? hreflangMap[key][1].pageType : ''}`;
           return {
             _attributes: {
               rel: 'alternate',


### PR DESCRIPTION
- The follow-up to https://github.com/hlxsites/bitdefender/pull/426, where we removed the initial hreflang implementation. This PR brings the implementation back – with one difference – it adds the hreflang in eager phase (not lazy phase).
- Fix an issue in sitemap creation

Test URLs:
- Before: https://main--bitdefender--hlxsites.hlx.page/solutions/
- After: https://add_hreflang--bitdefender--hlxsites.hlx.page/solutions/